### PR TITLE
Enable to use mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'mini_racer', platforms: :ruby
+gem 'mini_racer', platforms: :ruby
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    libv8 (8.4.255.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -156,6 +157,8 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minitest (5.14.3)
     msgpack (1.3.3)
     mustermann (1.1.1)
@@ -349,6 +352,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
+  mini_racer
   mysql2
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.4)


### PR DESCRIPTION
僕の環境だけの問題であればもちろん無視して頂いて良いのですが、これをenableにしないと `bundle exec rspec` も `bin/rails console` もうまく行かなかったので一応PRを送りますね 🙇 

試した環境
---

```sh
docker container run --user=root --volume="$(pwd)/:/usr/src/" --workdir='/usr/src/' -it 'ruby:2.6.3' '/bin/bash'
```

出たエラー
---


```
root@70a32850a2d2:/usr/src# bin/rails console
/usr/local/bundle/gems/execjs-2.7.0/lib/execjs/runtimes.rb:58:in `autodetect': Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
```

```
bundle exec rspec

An error occurred while loading ./spec/system/before_login_spec.rb.
Failure/Error: require File.expand_path('../config/environment', __dir__)

ExecJS::RuntimeUnavailable:
  Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
```

<img width="1120" alt="スクリーンショット 2021-02-20 3 26 39" src="https://user-images.githubusercontent.com/1180335/108545698-78a80f80-732b-11eb-9c59-d85e94b915ff.png">

最新のrailsでは不要になってそうな気配も感じますが、詳細は把握していないです 🙇 